### PR TITLE
Add session refresh & network reduction

### DIFF
--- a/TikTokApi/stealth/stealth.py
+++ b/TikTokApi/stealth/stealth.py
@@ -80,8 +80,8 @@ class StealthConfig:
     navigator_permissions: bool = True
     navigator_platform: bool = True
     navigator_plugins: bool = True
-    navigator_user_agent: bool = True
-    navigator_vendor: bool = True
+    navigator_user_agent: bool = False
+    navigator_vendor: bool = False
     outerdimensions: bool = True
     hairline: bool = True
 

--- a/TikTokApi/stealth/stealth.py
+++ b/TikTokApi/stealth/stealth.py
@@ -80,8 +80,8 @@ class StealthConfig:
     navigator_permissions: bool = True
     navigator_platform: bool = True
     navigator_plugins: bool = True
-    navigator_user_agent: bool = False
-    navigator_vendor: bool = False
+    navigator_user_agent: bool = True
+    navigator_vendor: bool = True
     outerdimensions: bool = True
     hairline: bool = True
 

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -471,6 +471,17 @@ class TikTokApi:
                 ]
                 await context.add_cookies(formatted_cookies)
 
+            def blockable_request(request):
+                if ((request.resource_type in suppress_resource_load_types) or re.match(
+                        r'https://(mon[^.]+\.tiktokv\.(com|eu|us)|m\.tiktok\.com|www\.tiktok\.com.ttwid.check)/.*',
+                        request.url)):
+                  self.logger.info(
+                      f"aborting request to {request.url}"
+                  )
+                  return True
+                else:
+                  return False
+
             if page_factory:
                 page = await page_factory(context)
             else:
@@ -496,10 +507,14 @@ class TikTokApi:
                 page.on("request", log_request)
                 page.on("response", log_response)
 
-                _ = await page.goto(url)
-
-            if "tiktok" not in page.url:
-                _ = await page.goto("https://www.tiktok.com")
+            if suppress_resource_load_types is not None:
+                await page.route(
+                    "**/*",
+                    lambda route, request: (
+                        route.abort() if (blockable_request(request))
+                        else route.continue_()
+                    ),
+                )
 
             # Get the request headers to the url
             request_headers = None
@@ -510,29 +525,11 @@ class TikTokApi:
 
             page.once("request", handle_request)
 
-            def blockable_request(request):
-                if ((request.resource_type in suppress_resource_load_types) or re.match(
-                        r'https://(mon[^.]+\.tiktokv\.(com|eu|us)|mcs[^.]+\.tiktokv\.(com|eu|us)|m\.tiktok\.com|www\.tiktok\.com.ttwid.check)/.*',
-                        request.url)):
-                  self.logger.info(
-                      f"aborting request to {request.url}"
-                  )
-                  return True
-                else:
-                  return False
-
-
-            if suppress_resource_load_types is not None:
-                await page.route(
-                    "**/*",
-                    lambda route, request: (
-                        route.abort() if (blockable_request(request))
-                        else route.continue_()
-                    ),
-                )
 
             # Set the navigation timeout
             page.set_default_navigation_timeout(timeout)
+
+            _ = await page.goto(url)
 
             # by doing this, we are simulate scroll event using mouse to `avoid` bot detection
             x, y = random.randint(0, 50), random.randint(0, 50)

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -485,12 +485,15 @@ class TikTokApi:
                         f"[{request.resource_type}]"
                     )
 
-                def log_response(response):
-                    size = response.headers.get('content-length', 'unknown')
+                async def log_response(response):
+                    size = await response.request.sizes()
+                    req_size = size['requestHeadersSize'] + size['requestBodySize']
+                    resp_size = size['responseHeadersSize'] + size['responseBodySize']
                     self.logger.debug(
                         f"← Response: {response.status} {response.url[:100]} "
-                        f"[{response.request.resource_type}] Size: {size} bytes"
-                        f"[Headers: {response.headers}"
+                        f"[{response.request.resource_type}] Sizes: request={req_size} bytes "
+                        f"response={resp_size} bytes"
+                        # f"[Headers: {response.headers}"
                     )
 
                 page.on("request", log_request)

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -260,6 +260,7 @@ class TikTokApi:
                 if i < len(self.sessions):
                     session = self.sessions[i]
                     if await self._is_session_valid(session):
+                        self.logger.info(f"Got a session & verified it's valid. Session " + i)
                         return i, session
                     else:
                         self.logger.warning(f"Requested session {i} is invalid")

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -466,7 +466,6 @@ class TikTokApi:
                     for k, v in cookies.items()
                     if v is not None
                 ]
-                self.logger.debug(f"Adding cookies to context: {formatted_cookies}")
                 await context.add_cookies(formatted_cookies)
 
             if page_factory:
@@ -476,11 +475,12 @@ class TikTokApi:
                 await stealth_async(page)
 
                 # Add network logging to track what's being loaded
-                def log_request(request):
+                async def log_request(request):
+                    contextCookies = await context.cookies()
                     self.logger.debug(
                         f"→ Request: {request.method} {request.url[:100]} "
                         f"[{request.resource_type}]"
-                        f"[Request headers: {request_headers}, Context cookies: {context.cookies()}]"
+                        f"[Request headers: {request_headers}, Context cookies: {contextCookies}]"
                     )
 
                 def log_response(response):

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -795,7 +795,7 @@ class TikTokApi:
 
                 try_urls = [
                     "https://www.tiktok.com/foryou",
-                    "https://www.tiktok.com",
+                    # "https://www.tiktok.com",
                     "https://www.tiktok.com/@tiktok",
                     "https://www.tiktok.com/foryou",
                 ]

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -486,6 +486,7 @@ class TikTokApi:
                     self.logger.debug(
                         f"← Response: {response.status} {response.url[:100]} "
                         f"[{response.request.resource_type}] Size: {size} bytes"
+                        f"[Headers: {response.headers}"
                     )
 
                 page.on("request", log_request)

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -479,7 +479,7 @@ class TikTokApi:
                     self.logger.debug(
                         f"→ Request: {request.method} {request.url[:100]} "
                         f"[{request.resource_type}]"
-                        f"[Request headers: {request_headers}]"
+                        f"[Request headers: {request_headers}. Cookies added to context: {formatted_cookies}]"
                     )
 
                 def log_response(response):

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -927,6 +927,7 @@ class TikTokApi:
                     self.logger.info(f"Returning result for request and closing session {i}")
                     await session.page.close()
                     await session.context.close()
+                    await self.browser.close()
                     ######
                     return result
                 except json.decoder.JSONDecodeError:

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -512,7 +512,7 @@ class TikTokApi:
                     "**/*",
                     lambda route, request: (
                         route.abort()
-                        if request.resource_type in suppress_resource_load_types
+                        if ((request.resource_type in suppress_resource_load_types) or ("tiktokv.com" in request.url))
                         else route.continue_()
                     ),
                 )

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -479,6 +479,7 @@ class TikTokApi:
                     self.logger.debug(
                         f"→ Request: {request.method} {request.url[:100]} "
                         f"[{request.resource_type}]"
+                        f"[Request headers: {request_headers}]"
                     )
 
                 def log_response(response):

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -883,10 +883,10 @@ class TikTokApi:
                     )
 
                 try:
-                    data = json.loads(result)
-                    if data.get("status_code") != 0:
-                        self.logger.error(f"Got an unexpected status code: {data}")
-                    return data
+                    # data = json.loads(result)
+                    # if data.get("status_code") != 0:
+                    #     self.logger.error(f"Got an unexpected status code: {data}")
+                    return result
                 except json.decoder.JSONDecodeError:
                     if retry_count == retries:
                         self.logger.error(f"Failed to decode json response: {result}")

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -911,6 +911,7 @@ class TikTokApi:
                     raise Exception("TikTokApi.run_fetch_script returned None")
 
                 if result == "":
+                    await self._mark_session_invalid(session)
                     raise EmptyResponseException(
                         result,
                         "TikTok returned an empty response. They are detecting you're a bot, try some of these: headless=False, browser='webkit', consider using a proxy",

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -480,7 +480,7 @@ class TikTokApi:
                     self.logger.debug(
                         f"→ Request: {request.method} {request.url[:100]} "
                         f"[{request.resource_type}]"
-                        f"[Request headers: {request_headers}]"
+                        f"[Request headers: {request_headers}, Context cookies: {context.cookies()}]"
                     )
 
                 def log_response(response):

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -865,10 +865,11 @@ class TikTokApi:
                     )
 
                 try_urls = [
-                    "https://www.tiktok.com/foryou",
-                    "https://www.tiktok.com",
-                    "https://www.tiktok.com/@tiktok",
-                    "https://www.tiktok.com/foryou",
+                    # "https://www.tiktok.com/foryou",
+                    # "https://www.tiktok.com",
+                    # "https://www.tiktok.com/@tiktok",
+                    # "https://www.tiktok.com/foryou",
+                    "https://www.tiktok.com/favicon.ico"
                 ]
 
                 await session.page.goto(random.choice(try_urls))

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -466,6 +466,7 @@ class TikTokApi:
                     for k, v in cookies.items()
                     if v is not None
                 ]
+                self.logger.debug(f"Adding cookies to context: {formatted_cookies}")
                 await context.add_cookies(formatted_cookies)
 
             if page_factory:
@@ -479,7 +480,7 @@ class TikTokApi:
                     self.logger.debug(
                         f"→ Request: {request.method} {request.url[:100]} "
                         f"[{request.resource_type}]"
-                        f"[Request headers: {request_headers}. Cookies added to context: {formatted_cookies}]"
+                        f"[Request headers: {request_headers}]"
                     )
 
                 def log_response(response):

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -865,11 +865,10 @@ class TikTokApi:
                     )
 
                 try_urls = [
-                    # "https://www.tiktok.com/foryou",
-                    # "https://www.tiktok.com",
-                    # "https://www.tiktok.com/@tiktok",
-                    # "https://www.tiktok.com/foryou",
-                    "https://www.tiktok.com/favicon.ico"
+                    "https://www.tiktok.com/foryou",
+                    "https://www.tiktok.com",
+                    "https://www.tiktok.com/@tiktok",
+                    "https://www.tiktok.com/foryou",
                 ]
 
                 await session.page.goto(random.choice(try_urls))

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -871,7 +871,9 @@ class TikTokApi:
                     "https://www.tiktok.com/foryou",
                 ]
 
-                await session.page.goto(random.choice(try_urls))
+                page = random.choice(try_urls)
+                self.logger.info(f"Timed out waiting for acrawler function. Reloading page: {page}")
+                await session.page.goto(page)
             except PlaywrightError as e:
                 # Session died
                 self.logger.error(f"Session died during x-bogus generation: {e}")

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -60,7 +60,6 @@ class TikTokPlaywrightSession:
     empty_response_count: int = 0
     successful_requests: int = 0
     total_requests: int = 0
-    bytes_downloaded: int = 0
 
 
 class TikTokApi:
@@ -231,12 +230,8 @@ class TikTokApi:
         if self._auto_cleanup_dead_sessions and session in self.sessions:
             try:
                 self.sessions.remove(session)
-                # Log session statistics including bandwidth
-                bandwidth_mb = session.bytes_downloaded / (1024 * 1024)
                 self.logger.info(
-                    f"Removed dead session from pool. Remaining: {len(self.sessions)} | "
-                    f"Session stats: {session.successful_requests} successful / {session.total_requests} total requests, "
-                    f"Bandwidth: {bandwidth_mb:.2f} MB ({session.bytes_downloaded:,} bytes)"
+                    f"Removed dead session from pool. Remaining: {len(self.sessions)}"
                 )
             except ValueError:
                 pass  # Session already removed
@@ -451,21 +446,6 @@ class TikTokApi:
                 is_valid=True,
             )
 
-            # Track bandwidth usage for this session
-            def track_response_size(response):
-                try:
-                    # Try to get content-length from headers
-                    content_length = response.headers.get('content-length')
-                    if content_length:
-                        session.bytes_downloaded += int(content_length)
-                    # If no content-length header, we can't track size without fetching body
-                    # which would be expensive, so we skip it
-                except Exception as e:
-                    # Silently ignore errors in bandwidth tracking
-                    pass
-
-            page.on("response", track_response_size)
-
             if ms_token is None:
                 await asyncio.sleep(
                     sleep_after
@@ -478,13 +458,6 @@ class TikTokApi:
                         f"Failed to get msToken on session index {len(self.sessions)}, you should consider specifying ms_tokens"
                     )
             self.sessions.append(session)
-
-            # Log initial session creation bandwidth
-            bandwidth_mb = session.bytes_downloaded / (1024 * 1024)
-            self.logger.info(
-                f"Session created successfully. Initial bandwidth: {bandwidth_mb:.2f} MB ({session.bytes_downloaded:,} bytes)"
-            )
-
             await self.__set_session_params(session)
         except Exception as e:
             # clean up

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -236,7 +236,7 @@ class TikTokApi:
         if self._auto_cleanup_dead_sessions and session in self.sessions:
             try:
                 self.sessions.remove(session)
-                self.logger.debug(
+                self.logger.info(
                     f"Automatically removed dead session from pool. Remaining: {len(self.sessions)}"
                 )
             except ValueError:
@@ -873,6 +873,8 @@ class TikTokApi:
             # Fallback to old method for backwards compatibility
             i, session = self._get_session(**kwargs)
 
+        self.logger.info(f"Got a session: {session} with index {i}")
+
         if session.params is not None:
             params = {**session.params, **params}
 
@@ -921,6 +923,11 @@ class TikTokApi:
                     # data = json.loads(result)
                     # if data.get("status_code") != 0:
                     #     self.logger.error(f"Got an unexpected status code: {data}")
+                    #####TESTING
+                    self.logger.info(f"Returning result for request and closing session {i}")
+                    await session.page.close
+                    await session.context.close
+                    ######
                     return result
                 except json.decoder.JSONDecodeError:
                     if retry_count == retries:

--- a/TikTokApi/tiktok.py
+++ b/TikTokApi/tiktok.py
@@ -925,8 +925,8 @@ class TikTokApi:
                     #     self.logger.error(f"Got an unexpected status code: {data}")
                     #####TESTING
                     self.logger.info(f"Returning result for request and closing session {i}")
-                    await session.page.close
-                    await session.context.close
+                    await session.page.close()
+                    await session.context.close()
                     ######
                     return result
                 except json.decoder.JSONDecodeError:


### PR DESCRIPTION
Extend the functionality of the TikTok-Api livrary by augmenting it with functionality to:
- Recreate invalid sessions automatically
- Add a threshold for session invalidity
- Block resources that are not needed in our scraper service (i.e. monitoring requests scheduled by TikTok) to reduce bandwidth usage.
- Optionally attempt msToken refreshes on invalid sessions by reloading the page
- Add additional debug output
